### PR TITLE
Fix for -z option being ignored in openpgp mode and incorrect filenames

### DIFF
--- a/src/gaaout.c
+++ b/src/gaaout.c
@@ -138,8 +138,8 @@ void gaa_help(void)
 	__gaa_helpsingle('k', "key", _("KEY1 KEY2...KEYN "), _("Specify the key(s)"));
 	__gaa_helpsingle(0, "noiv", "", _("Do not use an IV."));
 	__gaa_helpsingle('b', "bare", "", _("Do not keep algorithm information in the encrypted file."));
-	__gaa_helpsingle('z', "gzip", "", _("Use gzip to compress files before encryption."));
-	__gaa_helpsingle('p', "bzip2", "", _("Use bzip2 to compress files before encryption."));
+	__gaa_helpsingle('z', "gzip", "", _("Use gzip to compress/decompress files before/after encryption/decryption. NOTE: cannot be used if openpgp mode is active."));
+	__gaa_helpsingle('p', "bzip2", "", _("Use bzip2 to compress/decompress files before/after encryption/decryption. NOTE: cannot be used if openpgp mode is active."));
 	__gaa_helpsingle(0, "flush", "", _("Immediately flush the output"));
 	__gaa_helpsingle('l', "doublecheck", "", _("Double check passwords."));
 	__gaa_helpsingle('u', "unlink", "", _("Unlink the input file after encryption or decryption."));

--- a/src/mcrypt.c
+++ b/src/mcrypt.c
@@ -552,11 +552,15 @@ int main(int argc, char **argv)
 	       continue;
 	    }
 #ifdef ZIP
+	    if ((openpgp != 0) && ( gzipflag == TRUE || bzipflag == TRUE )) {
+		err_quit(_("Error: Cannot use -z with openpgp mode (does not call gzip or bzip)\n"));
+	    }
+
 	    if (stream_flag == FALSE) {
 	       if (gzipflag == TRUE)
-		  strcat(outfile, ".gz");
+		  if (openpgp == 0) strcat(outfile, ".gz");
 	       if (bzipflag == TRUE)
-		  strcat(outfile, ".bz2");
+		  if (openpgp == 0) strcat(outfile, ".bz2");
 	    }
 #endif
 	    strcat(outfile, ".nc");


### PR DESCRIPTION
See https://forums.gentoo.org/viewtopic-t-1070876.html

Summary: default (openpgp) mode does not properly handle addition and stripping of .gz/.bz 
file components, resulting in mismatching plaintext/decoded file names and misleads 
the user to believe openpgp ciphertext has been first compressed using external tools. 

mcrypt w/default config uses openpgp, but does not indicate that the -z option's calls 
to external gzip or bzip are not used in this mode. 

As compression before encryption is generally considered good for security, this is 
misleading and use of -z with the default openpgp mode should cause an error informing 
that the openpgp mode will not use external gzip/bzip tools prior to encryption. 

In addition, the .gz/.bz path component should *not* be added if the program is 
using openpgp mode and will not call gzip or bzip. Doing so results, on decryption, 
with a misleading .gz/.bz extension to the resulting (uncompressed) plaintext. 

Steps to Reproduce 

1. echo "plaintext" >foo.txt 
2. mcrypt -z foo.txt 
<passphrase> 
<matching passphrase> 
Result: foo.txt.gz.nc is written. Note this should be foo.txt.nc, as by default openpgp 
mode is active and no call to gzip is performed. 

3. mcrypt -dz foo.txt.gz.nc 
<passphrase> 
Result: foo.txt.gz is written (which is plaintext, not a .gz file), *not* foo.txt 